### PR TITLE
Add shared edit modals for customers and pets

### DIFF
--- a/api/src/repositories/pet-repository.ts
+++ b/api/src/repositories/pet-repository.ts
@@ -49,6 +49,15 @@ export async function createPet(values: PetInsert) {
   return rows[0] ?? null;
 }
 
+export async function updatePetById(petId: string, values: Partial<PetInsert>) {
+  const [row] = await db
+    .update(pets)
+    .set({ ...values, updatedAt: new Date() })
+    .where(eq(pets.id, petId))
+    .returning();
+  return row ?? null;
+}
+
 export async function softDeletePetById(petId: string) {
   await db.update(pets).set({ isDeleted: true, updatedAt: new Date() }).where(eq(pets.id, petId));
 }

--- a/api/src/routes/customers.ts
+++ b/api/src/routes/customers.ts
@@ -13,6 +13,7 @@ import {
   petResponseSchema,
   updateCustomerBodySchema,
   updateCustomerParamsSchema,
+  updatePetBodySchema,
 } from '@kalimere/types/customers';
 import { okResponseSchema } from '@kalimere/types/common';
 import { ensureCustomerOwnership, ensurePetOwnership } from '../middleware/ownership.js';
@@ -26,6 +27,7 @@ import {
   listCustomersForUser,
   listPetsForCustomer,
   updateCustomerForUser,
+  updatePetForCustomer,
 } from '../services/customer-service.js';
 
 const customerRoutesPlugin: FastifyPluginAsyncZod = async (app) => {
@@ -156,6 +158,29 @@ const customerRoutesPlugin: FastifyPluginAsyncZod = async (app) => {
       const customerId = req.params.id;
       const pet = await createPetForCustomer(customerId, req.body);
       return reply.code(201).send({ pet });
+    }
+  );
+
+  app.put(
+    '/customers/:customerId/pets/:petId',
+    {
+      preHandler: [
+        app.authenticate,
+        ensureCustomerOwnership('customerId'),
+        ensurePetOwnership('petId'),
+      ],
+      schema: {
+        params: customerPetParamsSchema,
+        body: updatePetBodySchema,
+        response: {
+          200: petResponseSchema,
+        },
+      },
+    },
+    async (req) => {
+      const customerId = req.params.customerId;
+      const pet = await updatePetForCustomer(customerId, req.params.petId, req.body);
+      return { pet };
     }
   );
 

--- a/api/src/services/customer-service.ts
+++ b/api/src/services/customer-service.ts
@@ -13,6 +13,7 @@ import {
   createPet,
   findActivePetsByCustomerId,
   findPetByIdForCustomer,
+  updatePetById,
   softDeletePetById,
   type PetInsert,
   type PetRecord,
@@ -24,6 +25,7 @@ import {
   type CreateCustomerBody,
   type UpdateCustomerBody,
   type CreatePetBody,
+  type UpdatePetBody,
 } from '@kalimere/types/customers';
 
 type CustomerDto = z.infer<typeof customerSchema>;
@@ -147,6 +149,26 @@ export async function createPetForCustomer(customerId: string, input: CreatePetB
   const record = await createPet(values as PetInsert);
   if (!record) throw new Error('Failed to create pet');
   return serializePet(record);
+}
+
+export async function updatePetForCustomer(customerId: string, petId: string, input: UpdatePetBody) {
+  const record = await findPetByIdForCustomer(customerId, petId);
+  if (!record) throw notFound();
+
+  const updates: Partial<PetInsert> = { updatedAt: new Date() };
+  if (input.name !== undefined) updates.name = input.name;
+  if (input.type !== undefined) updates.type = input.type;
+  if (input.gender !== undefined) updates.gender = input.gender;
+  if (input.breed !== undefined) updates.breed = input.breed ?? null;
+  if (input.isSterilized !== undefined) updates.isSterilized = input.isSterilized ?? null;
+  if (input.isCastrated !== undefined) updates.isCastrated = input.isCastrated ?? null;
+  if (input.dateOfBirth !== undefined) {
+    updates.dateOfBirth = typeof input.dateOfBirth === 'string' ? new Date(input.dateOfBirth) : null;
+  }
+
+  const updated = await updatePetById(petId, updates);
+  if (!updated) throw new Error('Failed to update pet');
+  return serializePet(updated);
 }
 
 export async function deletePetForCustomer(customerId: string, petId: string) {

--- a/api/src/services/customer-service.ts
+++ b/api/src/services/customer-service.ts
@@ -151,7 +151,11 @@ export async function createPetForCustomer(customerId: string, input: CreatePetB
   return serializePet(record);
 }
 
-export async function updatePetForCustomer(customerId: string, petId: string, input: UpdatePetBody) {
+export async function updatePetForCustomer(
+  customerId: string,
+  petId: string,
+  input: UpdatePetBody
+) {
   const record = await findPetByIdForCustomer(customerId, petId);
   if (!record) throw notFound();
 
@@ -163,7 +167,8 @@ export async function updatePetForCustomer(customerId: string, petId: string, in
   if (input.isSterilized !== undefined) updates.isSterilized = input.isSterilized ?? null;
   if (input.isCastrated !== undefined) updates.isCastrated = input.isCastrated ?? null;
   if (input.dateOfBirth !== undefined) {
-    updates.dateOfBirth = typeof input.dateOfBirth === 'string' ? new Date(input.dateOfBirth) : null;
+    updates.dateOfBirth =
+      typeof input.dateOfBirth === 'string' ? new Date(input.dateOfBirth) : null;
   }
 
   const updated = await updatePetById(petId, updates);

--- a/api/tests/routes/customers.test.ts
+++ b/api/tests/routes/customers.test.ts
@@ -114,6 +114,38 @@ describe('routes/customers', () => {
     ]);
   });
 
+  it('updates a pet and returns the updated data', async () => {
+    const { user, sessionId } = await createAuthedUser();
+    const customer = await seedCustomer(user.id, { name: 'Owner' });
+    const pet = await seedPet(customer.id, { name: 'Rex', type: 'dog', gender: 'male' });
+
+    const response = await injectAuthed(app, sessionId, {
+      method: 'PUT',
+      url: `/customers/${customer.id}/pets/${pet.id}`,
+      payload: { name: 'Rexy', breed: 'Labrador' },
+    });
+
+    const result = getJson<PetResponse>(response);
+    expect(result.statusCode).toBe(200);
+    expect(result.body.pet).toMatchObject({
+      id: pet.id,
+      name: 'Rexy',
+      breed: 'Labrador',
+      type: 'dog',
+      gender: 'male',
+    });
+
+    const petsResponse = await injectAuthed(app, sessionId, {
+      method: 'GET',
+      url: `/customers/${customer.id}/pets`,
+    });
+
+    const petsResult = getJson<CustomerPetsResponse>(petsResponse);
+    expect(petsResult.body.pets).toEqual([
+      expect.objectContaining({ id: pet.id, name: 'Rexy', breed: 'Labrador' }),
+    ]);
+  });
+
   it('returns full customer payload after creation', async () => {
     const { sessionId } = await createAuthedUser();
     const response = await injectAuthed(app, sessionId, {

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -91,8 +91,8 @@
 - [ ] filter/sort visits (by date, status, customer)
 
 ### Data Management
-- [ ] edit customer details
-- [ ] edit pet details
+- [x] edit customer details
+- [x] edit pet details
 - [ ] edit/cancel visits
 - [ ] edit/update treatment records
 

--- a/front/src/api/customers.ts
+++ b/front/src/api/customers.ts
@@ -2,12 +2,23 @@ import { fetchJson } from '../lib/http';
 import {
   createCustomerBodySchema,
   createPetBodySchema,
+  customerPetParamsSchema,
   customerPetsResponseSchema,
   customerResponseSchema,
   customersListResponseSchema,
   petResponseSchema,
+  updateCustomerBodySchema,
+  updateCustomerParamsSchema,
+  updatePetBodySchema,
 } from '@kalimere/types/customers';
-import type { CreateCustomerBody, CreatePetBody, Customer, Pet } from '@kalimere/types/customers';
+import type {
+  CreateCustomerBody,
+  CreatePetBody,
+  Customer,
+  Pet,
+  UpdateCustomerBody,
+  UpdatePetBody,
+} from '@kalimere/types/customers';
 
 export type {
   CreateCustomerBody,
@@ -18,6 +29,8 @@ export type {
   CustomersListResponse,
   Pet,
   PetResponse,
+  UpdateCustomerBody,
+  UpdatePetBody,
 } from '@kalimere/types/customers';
 
 export type PetSummary = Pick<Pet, 'id' | 'name' | 'type'>;
@@ -37,6 +50,17 @@ export async function createCustomer(input: CreateCustomerBody): Promise<Custome
   const payload = createCustomerBodySchema.parse(input);
   const json = await fetchJson<unknown>('/customers', {
     method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const result = customerResponseSchema.parse(json);
+  return result.customer;
+}
+
+export async function updateCustomer(customerId: string, input: UpdateCustomerBody): Promise<Customer> {
+  const params = updateCustomerParamsSchema.parse({ id: customerId });
+  const payload = updateCustomerBodySchema.parse(input);
+  const json = await fetchJson<unknown>(`/customers/${params.id}`, {
+    method: 'PUT',
     body: JSON.stringify(payload),
   });
   const result = customerResponseSchema.parse(json);
@@ -78,6 +102,21 @@ export async function addPetToCustomer(customerId: string, input: CreatePetBody)
   const payload = createPetBodySchema.parse(input);
   const json = await fetchJson<unknown>(`/customers/${customerId}/pets`, {
     method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  const result = petResponseSchema.parse(json);
+  return result.pet;
+}
+
+export async function updatePet(
+  customerId: string,
+  petId: string,
+  input: UpdatePetBody,
+): Promise<Pet> {
+  const params = customerPetParamsSchema.parse({ customerId, petId });
+  const payload = updatePetBodySchema.parse(input);
+  const json = await fetchJson<unknown>(`/customers/${params.customerId}/pets/${params.petId}`, {
+    method: 'PUT',
     body: JSON.stringify(payload),
   });
   const result = petResponseSchema.parse(json);

--- a/front/src/api/customers.ts
+++ b/front/src/api/customers.ts
@@ -56,7 +56,10 @@ export async function createCustomer(input: CreateCustomerBody): Promise<Custome
   return result.customer;
 }
 
-export async function updateCustomer(customerId: string, input: UpdateCustomerBody): Promise<Customer> {
+export async function updateCustomer(
+  customerId: string,
+  input: UpdateCustomerBody
+): Promise<Customer> {
   const params = updateCustomerParamsSchema.parse({ id: customerId });
   const payload = updateCustomerBodySchema.parse(input);
   const json = await fetchJson<unknown>(`/customers/${params.id}`, {
@@ -111,7 +114,7 @@ export async function addPetToCustomer(customerId: string, input: CreatePetBody)
 export async function updatePet(
   customerId: string,
   petId: string,
-  input: UpdatePetBody,
+  input: UpdatePetBody
 ): Promise<Pet> {
   const params = customerPetParamsSchema.parse({ customerId, petId });
   const payload = updatePetBodySchema.parse(input);

--- a/front/src/components/EntityFormModal.tsx
+++ b/front/src/components/EntityFormModal.tsx
@@ -1,0 +1,47 @@
+import { ReactNode } from 'react';
+import { Button, Group, Modal, Stack } from '@mantine/core';
+
+type EntityFormModalProps = {
+  opened: boolean;
+  onClose: () => void;
+  title: string;
+  mode: 'create' | 'edit';
+  onSubmit: () => void | Promise<unknown>;
+  children: ReactNode;
+  submitDisabled?: boolean;
+  submitLoading?: boolean;
+  cancelLabel?: string;
+  submitLabel?: string;
+};
+
+export function EntityFormModal({
+  opened,
+  onClose,
+  title,
+  mode,
+  onSubmit,
+  children,
+  submitDisabled,
+  submitLoading,
+  cancelLabel = 'ביטול',
+  submitLabel,
+}: EntityFormModalProps) {
+  const resolvedSubmitLabel = submitLabel ?? (mode === 'edit' ? 'שמור' : 'הוסף');
+
+  return (
+    <Modal opened={opened} onClose={onClose} title={title}>
+      <Stack>
+        {children}
+
+        <Group justify="right" mt="sm">
+          <Button variant="default" onClick={onClose}>
+            {cancelLabel}
+          </Button>
+          <Button onClick={() => void onSubmit()} loading={submitLoading} disabled={submitDisabled}>
+            {resolvedSubmitLabel}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/front/src/pages/CustomerDetail.tsx
+++ b/front/src/pages/CustomerDetail.tsx
@@ -24,16 +24,22 @@ import {
   deletePet,
   getCustomer,
   getCustomerPets,
+  updateCustomer,
+  updatePet,
   type Customer,
   type Pet,
+  type UpdateCustomerBody,
+  type UpdatePetBody,
 } from '../api/customers';
 import { StatusCard } from '../components/StatusCard';
 import { EntityCard } from '../components/EntityCard';
+import { EntityFormModal } from '../components/EntityFormModal';
 import { formatPetsCount } from '../utils/formatPetsCount';
 import { queryKeys } from '../lib/queryKeys';
 import { extractErrorMessage } from '../lib/notifications';
 import { HttpError } from '../lib/http';
 import { useApiMutation } from '../lib/useApiMutation';
+import { applyCustomerUpdates, applyPetUpdates } from '../utils/entityUpdates';
 
 export function CustomerDetail() {
   const { id } = useParams<{ id: string }>();
@@ -58,7 +64,12 @@ export function CustomerDetail() {
     enabled: Boolean(customerId),
   });
 
-  const [modalOpen, setModalOpen] = useState(false);
+  const [customerFormOpen, setCustomerFormOpen] = useState(false);
+  const [customerFormName, setCustomerFormName] = useState('');
+  const [customerFormEmail, setCustomerFormEmail] = useState('');
+  const [customerFormPhone, setCustomerFormPhone] = useState('');
+  const [customerFormAddress, setCustomerFormAddress] = useState('');
+  const [petFormOpen, setPetFormOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [petDeleteModalOpen, setPetDeleteModalOpen] = useState(false);
   const [petToDelete, setPetToDelete] = useState<{
@@ -66,10 +77,20 @@ export function CustomerDetail() {
     petId: string;
     petName: string;
   } | null>(null);
+  const [editingPetId, setEditingPetId] = useState<string | null>(null);
   const [petName, setPetName] = useState('');
   const [petType, setPetType] = useState<'dog' | 'cat' | ''>('');
   const [petGender, setPetGender] = useState<'male' | 'female' | ''>('');
   const [petBreed, setPetBreed] = useState('');
+
+  function closeCustomerForm() {
+    setCustomerFormOpen(false);
+  }
+
+  function closePetForm() {
+    setPetFormOpen(false);
+    setEditingPetId(null);
+  }
 
   const addPetMutation = useApiMutation({
     mutationFn: (payload: Parameters<typeof addPetToCustomer>[1]) =>
@@ -134,7 +155,7 @@ export function CustomerDetail() {
         }
         return [...old, data];
       });
-      setModalOpen(false);
+      closePetForm();
       setPetName('');
       setPetType('');
       setPetGender('');
@@ -144,6 +165,90 @@ export function CustomerDetail() {
       void queryClient.invalidateQueries({ queryKey: petsQueryKey });
       void queryClient.invalidateQueries({ queryKey: customerQueryKey });
       void queryClient.invalidateQueries({ queryKey: customersListKey });
+    },
+  });
+
+  const updateCustomerMutation = useApiMutation({
+    mutationFn: (payload: UpdateCustomerBody) => updateCustomer(customerId, payload),
+    successToast: { message: 'פרטי הלקוח עודכנו בהצלחה' },
+    errorToast: { fallbackMessage: 'עדכון פרטי הלקוח נכשל' },
+    onMutate: async (payload) => {
+      if (!customerId) return;
+      await queryClient.cancelQueries({ queryKey: customerQueryKey });
+      await queryClient.cancelQueries({ queryKey: customersListKey });
+      const previousCustomer = queryClient.getQueryData<Customer>(customerQueryKey);
+      const previousCustomers = queryClient.getQueryData<Customer[]>(customersListKey) ?? [];
+      if (previousCustomer) {
+        queryClient.setQueryData<Customer>(customerQueryKey, applyCustomerUpdates(previousCustomer, payload));
+      }
+      if (previousCustomers.length > 0) {
+        queryClient.setQueryData<Customer[]>(customersListKey, (old = []) =>
+          old.map((item) => (item.id === customerId ? applyCustomerUpdates(item, payload) : item))
+        );
+      }
+      return { previousCustomer, previousCustomers };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousCustomer !== undefined) {
+        queryClient.setQueryData<Customer | undefined>(customerQueryKey, context.previousCustomer);
+      }
+      if (context?.previousCustomers) {
+        queryClient.setQueryData(customersListKey, context.previousCustomers);
+      }
+    },
+    onSuccess: (data, _variables, context) => {
+      queryClient.setQueryData<Customer | undefined>(customerQueryKey, data ?? context?.previousCustomer);
+      if (context?.previousCustomers) {
+        queryClient.setQueryData<Customer[]>(customersListKey, (old = []) =>
+          old.map((item) => (item.id === (data?.id ?? customerId) ? (data ?? item) : item))
+        );
+      }
+      closeCustomerForm();
+    },
+    onSettled: () => {
+      if (!customerId) return;
+      void queryClient.invalidateQueries({ queryKey: customerQueryKey });
+      void queryClient.invalidateQueries({ queryKey: customersListKey });
+    },
+  });
+
+  const updatePetMutation = useApiMutation({
+    mutationFn: ({ petId, payload }: { petId: string; payload: UpdatePetBody }) =>
+      updatePet(customerId, petId, payload),
+    successToast: { message: 'חיית המחמד עודכנה בהצלחה' },
+    errorToast: { fallbackMessage: 'עדכון חיית המחמד נכשל' },
+    onMutate: async ({ petId, payload }) => {
+      if (!customerId) return;
+      await queryClient.cancelQueries({ queryKey: petsQueryKey });
+      const previousPets = queryClient.getQueryData<Pet[]>(petsQueryKey) ?? [];
+      queryClient.setQueryData<Pet[]>(petsQueryKey, (old = []) =>
+        old.map((pet) => (pet.id === petId ? applyPetUpdates(pet, payload) : pet))
+      );
+      return { previousPets };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousPets) {
+        queryClient.setQueryData(petsQueryKey, context.previousPets);
+      }
+    },
+    onSuccess: (data, variables) => {
+      if (!variables) {
+        closePetForm();
+        return;
+      }
+      const { petId, payload } = variables;
+      queryClient.setQueryData<Pet[]>(petsQueryKey, (old = []) =>
+        old.map((pet) =>
+          pet.id === (data?.id ?? petId)
+            ? data ?? applyPetUpdates(pet, payload)
+            : pet
+        )
+      );
+      closePetForm();
+    },
+    onSettled: () => {
+      if (!customerId) return;
+      void queryClient.invalidateQueries({ queryKey: petsQueryKey });
     },
   });
 
@@ -246,6 +351,8 @@ export function CustomerDetail() {
   const customer = customerQuery.data;
   const pets: Pet[] = petsQuery.data ?? [];
   const petCount = pets.length;
+  const petMutationInFlight = addPetMutation.isPending || updatePetMutation.isPending;
+  const customerMutationInFlight = updateCustomerMutation.isPending;
 
   const breadcrumbItems = useMemo(
     () =>
@@ -317,21 +424,60 @@ export function CustomerDetail() {
   }
 
   function openAddPet() {
+    setEditingPetId(null);
     setPetName('');
     setPetType('');
     setPetGender('');
     setPetBreed('');
-    setModalOpen(true);
+    setPetFormOpen(true);
   }
 
-  async function onAddPet() {
+  function openEditPet(pet: Pet) {
+    setEditingPetId(pet.id);
+    setPetName(pet.name);
+    setPetType(pet.type);
+    setPetGender(pet.gender);
+    setPetBreed(pet.breed ?? '');
+    setPetFormOpen(true);
+  }
+
+  async function onSubmitPet() {
     if (!petName || !petType || !petGender) return;
-    await addPetMutation.mutateAsync({
-      name: petName,
-      type: petType,
-      gender: petGender,
-      breed: petBreed || null,
-    });
+    if (!editingPetId) {
+      await addPetMutation.mutateAsync({
+        name: petName,
+        type: petType,
+        gender: petGender,
+        breed: petBreed || null,
+      });
+    } else {
+      const payload: UpdatePetBody = {
+        name: petName,
+        type: petType,
+        gender: petGender,
+        breed: petBreed || null,
+      };
+      await updatePetMutation.mutateAsync({ petId: editingPetId, payload });
+    }
+  }
+
+  function openCustomerEdit() {
+    setCustomerFormName(customer.name);
+    setCustomerFormEmail(customer.email ?? '');
+    setCustomerFormPhone(customer.phone ?? '');
+    setCustomerFormAddress(customer.address ?? '');
+    setCustomerFormOpen(true);
+  }
+
+  async function onSubmitCustomerForm() {
+    if (!customerFormName) return;
+    const payload: UpdateCustomerBody = {
+      name: customerFormName,
+      email: customerFormEmail || null,
+      phone: customerFormPhone || null,
+      address: customerFormAddress || null,
+    };
+    await updateCustomerMutation.mutateAsync(payload);
   }
 
   function openDeleteModal() {
@@ -404,6 +550,7 @@ export function CustomerDetail() {
             {formatPetsCount(petCount)}
           </Badge>
         }
+        editAction={openCustomerEdit}
         className="customer-info-card"
       >
         <Stack gap={4}>
@@ -442,7 +589,7 @@ export function CustomerDetail() {
 
       <Group justify="space-between" mb="md">
         <Title order={3}>חיות מחמד</Title>
-        <Button onClick={openAddPet} disabled={addPetMutation.isPending}>
+        <Button onClick={openAddPet} disabled={petMutationInFlight}>
           + הוסף חיה
         </Button>
       </Group>
@@ -469,6 +616,7 @@ export function CustomerDetail() {
                 label: 'מחק חיית מחמד',
                 onClick: () => openPetDeleteModal(customer.id, pet.id, pet.name),
               }}
+              editAction={() => openEditPet(pet)}
               onClick={() => navigate(`/customers/${customer.id}/pets/${pet.id}`)}
               className="pet-card"
             />
@@ -476,55 +624,83 @@ export function CustomerDetail() {
         </SimpleGrid>
       )}
 
-      <Modal opened={modalOpen} onClose={() => setModalOpen(false)} title="הוסף חיה חדשה">
-        <Stack>
-          <TextInput
-            label="שם"
-            value={petName}
-            onChange={({ currentTarget }) => setPetName(currentTarget.value)}
-            required
-          />
-          <Select
-            label="סוג"
-            placeholder="בחר סוג"
-            data={[
-              { value: 'dog', label: 'כלב' },
-              { value: 'cat', label: 'חתול' },
-            ]}
-            value={petType}
-            onChange={(val) => setPetType((val as 'dog' | 'cat') ?? '')}
-            required
-          />
-          <Select
-            label="מין"
-            placeholder="בחר מין"
-            data={[
-              { value: 'male', label: 'זכר' },
-              { value: 'female', label: 'נקבה' },
-            ]}
-            value={petGender}
-            onChange={(val) => setPetGender((val as 'male' | 'female') ?? '')}
-            required
-          />
-          <TextInput
-            label="גזע"
-            value={petBreed}
-            onChange={({ currentTarget }) => setPetBreed(currentTarget.value)}
-          />
-          <Group justify="right" mt="sm">
-            <Button variant="default" onClick={() => setModalOpen(false)}>
-              ביטול
-            </Button>
-            <Button
-              onClick={onAddPet}
-              disabled={!petName || !petType || !petGender}
-              loading={addPetMutation.isPending}
-            >
-              הוסף
-            </Button>
-          </Group>
-        </Stack>
-      </Modal>
+      <EntityFormModal
+        opened={petFormOpen}
+        onClose={closePetForm}
+        title={editingPetId ? 'עריכת חיית מחמד' : 'הוסף חיה חדשה'}
+        mode={editingPetId ? 'edit' : 'create'}
+        onSubmit={onSubmitPet}
+        submitDisabled={!petName || !petType || !petGender}
+        submitLoading={petMutationInFlight}
+      >
+        <TextInput
+          label="שם"
+          value={petName}
+          onChange={({ currentTarget }) => setPetName(currentTarget.value)}
+          required
+        />
+        <Select
+          label="סוג"
+          placeholder="בחר סוג"
+          data={[
+            { value: 'dog', label: 'כלב' },
+            { value: 'cat', label: 'חתול' },
+          ]}
+          value={petType}
+          onChange={(val) => setPetType((val as 'dog' | 'cat') ?? '')}
+          required
+        />
+        <Select
+          label="מין"
+          placeholder="בחר מין"
+          data={[
+            { value: 'male', label: 'זכר' },
+            { value: 'female', label: 'נקבה' },
+          ]}
+          value={petGender}
+          onChange={(val) => setPetGender((val as 'male' | 'female') ?? '')}
+          required
+        />
+        <TextInput
+          label="גזע"
+          value={petBreed}
+          onChange={({ currentTarget }) => setPetBreed(currentTarget.value)}
+        />
+      </EntityFormModal>
+
+      <EntityFormModal
+        opened={customerFormOpen}
+        onClose={closeCustomerForm}
+        title="עריכת לקוח"
+        mode="edit"
+        onSubmit={onSubmitCustomerForm}
+        submitDisabled={!customerFormName}
+        submitLoading={customerMutationInFlight}
+      >
+        <TextInput
+          label="שם"
+          value={customerFormName}
+          onChange={({ currentTarget }) => setCustomerFormName(currentTarget.value)}
+          required
+        />
+        <TextInput
+          label="אימייל"
+          type="email"
+          value={customerFormEmail}
+          onChange={({ currentTarget }) => setCustomerFormEmail(currentTarget.value)}
+        />
+        <TextInput
+          label="טלפון"
+          type="tel"
+          value={customerFormPhone}
+          onChange={({ currentTarget }) => setCustomerFormPhone(currentTarget.value)}
+        />
+        <TextInput
+          label="כתובת"
+          value={customerFormAddress}
+          onChange={({ currentTarget }) => setCustomerFormAddress(currentTarget.value)}
+        />
+      </EntityFormModal>
 
       <Modal opened={deleteModalOpen} onClose={() => setDeleteModalOpen(false)} title="מחיקת לקוח">
         <Stack>

--- a/front/src/pages/CustomerDetail.tsx
+++ b/front/src/pages/CustomerDetail.tsx
@@ -179,7 +179,10 @@ export function CustomerDetail() {
       const previousCustomer = queryClient.getQueryData<Customer>(customerQueryKey);
       const previousCustomers = queryClient.getQueryData<Customer[]>(customersListKey) ?? [];
       if (previousCustomer) {
-        queryClient.setQueryData<Customer>(customerQueryKey, applyCustomerUpdates(previousCustomer, payload));
+        queryClient.setQueryData<Customer>(
+          customerQueryKey,
+          applyCustomerUpdates(previousCustomer, payload)
+        );
       }
       if (previousCustomers.length > 0) {
         queryClient.setQueryData<Customer[]>(customersListKey, (old = []) =>
@@ -197,7 +200,10 @@ export function CustomerDetail() {
       }
     },
     onSuccess: (data, _variables, context) => {
-      queryClient.setQueryData<Customer | undefined>(customerQueryKey, data ?? context?.previousCustomer);
+      queryClient.setQueryData<Customer | undefined>(
+        customerQueryKey,
+        data ?? context?.previousCustomer
+      );
       if (context?.previousCustomers) {
         queryClient.setQueryData<Customer[]>(customersListKey, (old = []) =>
           old.map((item) => (item.id === (data?.id ?? customerId) ? (data ?? item) : item))
@@ -239,9 +245,7 @@ export function CustomerDetail() {
       const { petId, payload } = variables;
       queryClient.setQueryData<Pet[]>(petsQueryKey, (old = []) =>
         old.map((pet) =>
-          pet.id === (data?.id ?? petId)
-            ? data ?? applyPetUpdates(pet, payload)
-            : pet
+          pet.id === (data?.id ?? petId) ? (data ?? applyPetUpdates(pet, payload)) : pet
         )
       );
       closePetForm();

--- a/front/src/pages/Customers.tsx
+++ b/front/src/pages/Customers.tsx
@@ -139,7 +139,10 @@ export function Customers() {
       await queryClient.cancelQueries({ queryKey: customerKey });
       const previousCustomer = queryClient.getQueryData<Customer>(customerKey);
       if (previousCustomer) {
-        queryClient.setQueryData<Customer>(customerKey, applyCustomerUpdates(previousCustomer, payload));
+        queryClient.setQueryData<Customer>(
+          customerKey,
+          applyCustomerUpdates(previousCustomer, payload)
+        );
       }
       return { previousCustomers, previousCustomer, customerKey };
     },
@@ -159,7 +162,7 @@ export function Customers() {
         sortCustomers(
           old.map((customer) =>
             customer.id === (data?.id ?? id)
-              ? data ?? applyCustomerUpdates(customer, payload)
+              ? (data ?? applyCustomerUpdates(customer, payload))
               : customer
           )
         )
@@ -167,7 +170,10 @@ export function Customers() {
       if (context?.customerKey) {
         queryClient.setQueryData<Customer>(
           context.customerKey,
-          data ?? (context.previousCustomer ? applyCustomerUpdates(context.previousCustomer, payload) : context.previousCustomer)
+          data ??
+            (context.previousCustomer
+              ? applyCustomerUpdates(context.previousCustomer, payload)
+              : context.previousCustomer)
         );
       }
       closeFormModal();

--- a/front/src/pages/Treatments.tsx
+++ b/front/src/pages/Treatments.tsx
@@ -23,6 +23,7 @@ import {
 } from '../api/treatments';
 import { StatusCard } from '../components/StatusCard';
 import { EntityCard } from '../components/EntityCard';
+import { EntityFormModal } from '../components/EntityFormModal';
 import { queryKeys } from '../lib/queryKeys';
 import { extractErrorMessage } from '../lib/notifications';
 import { useApiMutation } from '../lib/useApiMutation';
@@ -291,43 +292,37 @@ export function Treatments() {
         </SimpleGrid>
       )}
 
-      <Modal
+      <EntityFormModal
         opened={modalOpen}
         onClose={() => setModalOpen(false)}
         title={editId ? 'עריכת טיפול' : 'טיפול חדש'}
+        mode={editId ? 'edit' : 'create'}
+        onSubmit={onSubmit}
+        submitLoading={mutationInFlight}
+        submitDisabled={!name}
       >
-        <Stack>
-          <TextInput
-            label="שם"
-            value={name}
-            onChange={({ currentTarget }) => setName(currentTarget.value)}
-            required
-          />
-          <NumberInput
-            label="מרווח ברירת מחדל (חודשים)"
-            value={defaultIntervalMonths}
-            onChange={(val) => setDefaultIntervalMonths(typeof val === 'number' ? val : '')}
-            min={0}
-            clampBehavior="strict"
-          />
-          <NumberInput
-            label="מחיר"
-            value={price}
-            onChange={(val) => setPrice(typeof val === 'number' ? val : '')}
-            min={0}
-            clampBehavior="strict"
-            leftSection={<Text size="sm">₪</Text>}
-          />
-          <Group justify="right" mt="sm">
-            <Button variant="default" onClick={() => setModalOpen(false)}>
-              ביטול
-            </Button>
-            <Button onClick={onSubmit} loading={mutationInFlight} disabled={!name}>
-              {editId ? 'שמור' : 'הוסף'}
-            </Button>
-          </Group>
-        </Stack>
-      </Modal>
+        <TextInput
+          label="שם"
+          value={name}
+          onChange={({ currentTarget }) => setName(currentTarget.value)}
+          required
+        />
+        <NumberInput
+          label="מרווח ברירת מחדל (חודשים)"
+          value={defaultIntervalMonths}
+          onChange={(val) => setDefaultIntervalMonths(typeof val === 'number' ? val : '')}
+          min={0}
+          clampBehavior="strict"
+        />
+        <NumberInput
+          label="מחיר"
+          value={price}
+          onChange={(val) => setPrice(typeof val === 'number' ? val : '')}
+          min={0}
+          clampBehavior="strict"
+          leftSection={<Text size="sm">₪</Text>}
+        />
+      </EntityFormModal>
 
       <Modal opened={deleteModalOpen} onClose={() => setDeleteModalOpen(false)} title="מחיקת טיפול">
         <Stack>

--- a/front/src/test/pages/CustomerDetail.mutationHandlers.test.tsx
+++ b/front/src/test/pages/CustomerDetail.mutationHandlers.test.tsx
@@ -124,6 +124,10 @@ describe('CustomerDetail mutation handlers', () => {
     vi.restoreAllMocks();
   });
 
+  function getMutationBySuccessMessage(message: string) {
+    return capturedMutations.find((options) => options.successToast?.message === message);
+  }
+
   function renderPage() {
     renderWithProviders(
       <Routes>
@@ -135,7 +139,7 @@ describe('CustomerDetail mutation handlers', () => {
 
   it('restores cached data when add pet mutation fails', () => {
     renderPage();
-    const addPetOptions = capturedMutations[0];
+    const addPetOptions = getMutationBySuccessMessage('חיית המחמד נוספה בהצלחה');
     if (!addPetOptions?.onError) throw new Error('addPet onError handler missing');
 
     const context = {
@@ -162,7 +166,7 @@ describe('CustomerDetail mutation handlers', () => {
 
   it('restores cached data when delete customer mutation fails', () => {
     renderPage();
-    const deleteCustomerOptions = capturedMutations[1];
+    const deleteCustomerOptions = getMutationBySuccessMessage('הלקוח נמחק');
     if (!deleteCustomerOptions?.onError) throw new Error('deleteCustomer onError handler missing');
 
     const context = {
@@ -194,7 +198,7 @@ describe('CustomerDetail mutation handlers', () => {
 
   it('restores cached data when delete pet mutation fails', () => {
     renderPage();
-    const deletePetOptions = capturedMutations[2];
+    const deletePetOptions = getMutationBySuccessMessage('חיית המחמד נמחקה');
     if (!deletePetOptions?.onError) throw new Error('deletePet onError handler missing');
 
     const context = {

--- a/front/src/test/pages/CustomerDetail.test.tsx
+++ b/front/src/test/pages/CustomerDetail.test.tsx
@@ -50,6 +50,8 @@ describe('CustomerDetail page', () => {
   const deleteCustomerMock = vi.mocked(customersApi.deleteCustomer);
   const deletePetMock = vi.mocked(customersApi.deletePet);
   const getCustomerPetsMock = vi.mocked(customersApi.getCustomerPets);
+  const updateCustomerMock = vi.mocked(customersApi.updateCustomer);
+  const updatePetMock = vi.mocked(customersApi.updatePet);
   let restoreConsoleError: (() => void) | null = null;
 
   beforeEach(() => {
@@ -71,8 +73,86 @@ describe('CustomerDetail page', () => {
     });
     deleteCustomerMock.mockResolvedValue();
     deletePetMock.mockResolvedValue();
+    updateCustomerMock.mockResolvedValue(baseCustomer);
+    updatePetMock.mockResolvedValue(enrichPet(basePets[0]!));
     restoreConsoleError?.();
     restoreConsoleError = null;
+  });
+
+  it('allows editing customer details', async () => {
+    updateCustomerMock.mockResolvedValue({
+      ...baseCustomer,
+      name: 'Dana Updated',
+      phone: '050-9999999',
+      email: null,
+      address: null,
+    });
+
+    renderCustomerDetail();
+
+    await waitFor(() => expect(getCustomerMock).toHaveBeenCalled());
+
+    const user = userEvent.setup();
+    const customerInfoCard = (await screen.findByText('פרטי לקוח')).closest(
+      '.customer-info-card'
+    );
+    if (!customerInfoCard) throw new Error('Customer info card not found');
+    const editButton = within(customerInfoCard).getByRole('button', { name: 'ערוך' });
+    await user.click(editButton);
+
+    const dialog = await screen.findByRole('dialog', { name: 'עריכת לקוח' });
+    const nameInput = within(dialog).getByLabelText(/שם/);
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Dana Updated');
+    const phoneInput = within(dialog).getByLabelText(/טלפון/);
+    await user.clear(phoneInput);
+    await user.type(phoneInput, '050-9999999');
+    const emailInput = within(dialog).getByLabelText(/אימייל/);
+    await user.clear(emailInput);
+    const addressInput = within(dialog).getByLabelText(/כתובת/);
+    await user.clear(addressInput);
+
+    await user.click(within(dialog).getByRole('button', { name: 'שמור' }));
+
+    await waitFor(() => expect(updateCustomerMock).toHaveBeenCalled());
+    expect(updateCustomerMock).toHaveBeenCalledWith('cust-1', {
+      name: 'Dana Updated',
+      email: null,
+      phone: '050-9999999',
+      address: null,
+    });
+  });
+
+  it('allows editing a pet', async () => {
+    updatePetMock.mockResolvedValue({
+      ...enrichPet(basePets[0]!),
+      name: 'Bolt Updated',
+    });
+
+    renderCustomerDetail();
+
+    await waitFor(() => expect(getCustomerPetsMock).toHaveBeenCalled());
+
+    const user = userEvent.setup();
+    const boltCard = (await screen.findByText('Bolt')).closest('.pet-card');
+    if (!boltCard) throw new Error('Pet card not found');
+
+    await user.click(within(boltCard).getByRole('button', { name: 'ערוך' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'עריכת חיית מחמד' });
+    const nameInput = within(dialog).getByLabelText(/שם/);
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Bolt Updated');
+
+    await user.click(within(dialog).getByRole('button', { name: 'שמור' }));
+
+    await waitFor(() => expect(updatePetMock).toHaveBeenCalled());
+    expect(updatePetMock).toHaveBeenCalledWith('cust-1', 'pet-1', {
+      name: 'Bolt Updated',
+      type: 'dog',
+      gender: 'male',
+      breed: null,
+    });
   });
 
   afterEach(() => {
@@ -158,7 +238,9 @@ describe('CustomerDetail page', () => {
     expect(titleGroup).toBeInTheDocument();
 
     // Find the menu button that's a direct child of the title group
-    const menuButton = within(titleGroup as HTMLElement).getByRole('button');
+    const menuButton = within(titleGroup as HTMLElement).getByRole('button', {
+      name: 'פתח תפריט פעולות לקוח',
+    });
 
     // Click the menu button to open the dropdown
     await user.click(menuButton);

--- a/front/src/test/pages/CustomerDetail.test.tsx
+++ b/front/src/test/pages/CustomerDetail.test.tsx
@@ -93,9 +93,7 @@ describe('CustomerDetail page', () => {
     await waitFor(() => expect(getCustomerMock).toHaveBeenCalled());
 
     const user = userEvent.setup();
-    const customerInfoCard = (await screen.findByText('פרטי לקוח')).closest(
-      '.customer-info-card'
-    );
+    const customerInfoCard = (await screen.findByText('פרטי לקוח')).closest('.customer-info-card');
     if (!customerInfoCard) throw new Error('Customer info card not found');
     const editButton = within(customerInfoCard).getByRole('button', { name: 'ערוך' });
     await user.click(editButton);

--- a/front/src/utils/entityUpdates.ts
+++ b/front/src/utils/entityUpdates.ts
@@ -1,0 +1,36 @@
+import type {
+  Customer,
+  Pet,
+  UpdateCustomerBody,
+  UpdatePetBody,
+} from '../api/customers';
+
+export function applyCustomerUpdates(customer: Customer, payload: UpdateCustomerBody): Customer {
+  return {
+    ...customer,
+    name: payload.name ?? customer.name,
+    email: payload.email !== undefined ? payload.email : customer.email,
+    phone: payload.phone !== undefined ? payload.phone : customer.phone,
+    address: payload.address !== undefined ? payload.address : customer.address,
+  };
+}
+
+export function applyPetUpdates(pet: Pet, payload: UpdatePetBody): Pet {
+  return {
+    ...pet,
+    name: payload.name ?? pet.name,
+    type: payload.type ?? pet.type,
+    gender: payload.gender ?? pet.gender,
+    dateOfBirth:
+      payload.dateOfBirth !== undefined
+        ? payload.dateOfBirth === null
+          ? null
+          : payload.dateOfBirth
+        : pet.dateOfBirth,
+    breed: payload.breed !== undefined ? payload.breed : pet.breed,
+    isSterilized:
+      payload.isSterilized !== undefined ? payload.isSterilized : pet.isSterilized,
+    isCastrated:
+      payload.isCastrated !== undefined ? payload.isCastrated : pet.isCastrated,
+  };
+}

--- a/front/src/utils/entityUpdates.ts
+++ b/front/src/utils/entityUpdates.ts
@@ -1,9 +1,4 @@
-import type {
-  Customer,
-  Pet,
-  UpdateCustomerBody,
-  UpdatePetBody,
-} from '../api/customers';
+import type { Customer, Pet, UpdateCustomerBody, UpdatePetBody } from '../api/customers';
 
 export function applyCustomerUpdates(customer: Customer, payload: UpdateCustomerBody): Customer {
   return {
@@ -28,9 +23,7 @@ export function applyPetUpdates(pet: Pet, payload: UpdatePetBody): Pet {
           : payload.dateOfBirth
         : pet.dateOfBirth,
     breed: payload.breed !== undefined ? payload.breed : pet.breed,
-    isSterilized:
-      payload.isSterilized !== undefined ? payload.isSterilized : pet.isSterilized,
-    isCastrated:
-      payload.isCastrated !== undefined ? payload.isCastrated : pet.isCastrated,
+    isSterilized: payload.isSterilized !== undefined ? payload.isSterilized : pet.isSterilized,
+    isCastrated: payload.isCastrated !== undefined ? payload.isCastrated : pet.isCastrated,
   };
 }

--- a/types/src/customers.ts
+++ b/types/src/customers.ts
@@ -110,6 +110,27 @@ export const customerPetsResponseSchema = z.object({
   pets: z.array(petSchema),
 });
 
+export const updatePetBodySchema = z
+  .object({
+    name: nonEmptyString.optional(),
+    type: petTypeSchema.optional(),
+    gender: petGenderSchema.optional(),
+    dateOfBirth: optionalNullableDateInput,
+    breed: optionalNullableString,
+    isSterilized: optionalNullableBoolean,
+    isCastrated: optionalNullableBoolean,
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    if (!Object.values(data).some((value) => value !== undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'At least one field must be provided',
+        path: [],
+      });
+    }
+  });
+
 export type Customer = z.infer<typeof customerSchema>;
 export type CustomersListResponse = z.infer<typeof customersListResponseSchema>;
 export type CustomerResponse = z.infer<typeof customerResponseSchema>;
@@ -124,3 +145,4 @@ export type CreatePetBody = z.infer<typeof createPetBodySchema>;
 export type CustomerPetsParams = z.infer<typeof customerPetsParamsSchema>;
 export type CustomerPetParams = z.infer<typeof customerPetParamsSchema>;
 export type CustomerPetsResponse = z.infer<typeof customerPetsResponseSchema>;
+export type UpdatePetBody = z.infer<typeof updatePetBodySchema>;


### PR DESCRIPTION
## Summary
- introduce a reusable `EntityFormModal` component and refactor the treatments, customers, and customer detail pages to use it for create/edit flows
- add customer and pet update APIs plus client-side helpers so customer and pet cards can be edited inline with optimistic updates
- wire backend pet update support, extend schemas, and cover the new route with tests while keeping the TODO list current

## Testing
- npm run test --workspace front -- src/test/pages/CustomerDetail.test.tsx
- npm run test --workspace front -- src/test/pages/Customers.test.tsx
- npm run test --workspace api *(fails: TEST_DATABASE_URL is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68f3b4b4b0048322a62496986a1d3ded