### PR TITLE
feat: enable pet editing from customer and detail pages

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -46,7 +46,7 @@
 ### DevOps / Infrastructure (DO NOW)
 - [x] support PR environments - OAuth redirects to prod instead of staying on PR env (e.g., front-kalimere-pr-1.up.railway.app/login redirects to prod)
 - [x] run all tests on prs 
-- [ ] switch API tests to pg-mem (or similar) for local runs
+- [x] switch API tests to pg-mem (or similar) for local runs
 
 ### Security & Data Integrity (DO NOW)
 - [x] add rate limiting middleware (fastify-rate-limit)

--- a/front/src/components/PetFormModal.tsx
+++ b/front/src/components/PetFormModal.tsx
@@ -69,7 +69,13 @@ export function PetFormModal({
       gender: initialValues?.gender ?? '',
       breed: initialValues?.breed ?? '',
     });
-  }, [opened, initialValues?.name, initialValues?.type, initialValues?.gender, initialValues?.breed]);
+  }, [
+    opened,
+    initialValues?.name,
+    initialValues?.type,
+    initialValues?.gender,
+    initialValues?.breed,
+  ]);
 
   const submitDisabled = useMemo(() => {
     return values.name.trim() === '' || values.type === '' || values.gender === '';
@@ -103,7 +109,9 @@ export function PetFormModal({
       <TextInput
         label="שם"
         value={values.name}
-        onChange={({ currentTarget }) => setValues((prev) => ({ ...prev, name: currentTarget.value }))}
+        onChange={({ currentTarget }) =>
+          setValues((prev) => ({ ...prev, name: currentTarget.value }))
+        }
         required
       />
       <Select
@@ -129,7 +137,9 @@ export function PetFormModal({
       <TextInput
         label="גזע"
         value={values.breed}
-        onChange={({ currentTarget }) => setValues((prev) => ({ ...prev, breed: currentTarget.value }))}
+        onChange={({ currentTarget }) =>
+          setValues((prev) => ({ ...prev, breed: currentTarget.value }))
+        }
       />
     </EntityFormModal>
   );

--- a/front/src/components/PetFormModal.tsx
+++ b/front/src/components/PetFormModal.tsx
@@ -104,7 +104,7 @@ export function PetFormModal({
       mode={mode}
       onSubmit={handleSubmit}
       submitDisabled={submitDisabled}
-      submitLoading={submitLoading}
+      submitLoading={submitLoading ?? false}
     >
       <TextInput
         label="שם"

--- a/front/src/components/PetFormModal.tsx
+++ b/front/src/components/PetFormModal.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Select, TextInput } from '@mantine/core';
+import { EntityFormModal } from './EntityFormModal';
+
+export type PetFormValues = {
+  name: string;
+  type: '' | 'dog' | 'cat';
+  gender: '' | 'male' | 'female';
+  breed: string;
+};
+
+export type PetFormSubmitValues = {
+  name: string;
+  type: 'dog' | 'cat';
+  gender: 'male' | 'female';
+  breed: string | null;
+};
+
+export type PetFormModalInitialValues = Partial<Omit<PetFormValues, 'type' | 'gender'>> & {
+  type?: 'dog' | 'cat';
+  gender?: 'male' | 'female';
+};
+
+const initialFormValues: PetFormValues = {
+  name: '',
+  type: '',
+  gender: '',
+  breed: '',
+};
+
+const petTypeOptions = [
+  { value: 'dog', label: 'כלב' },
+  { value: 'cat', label: 'חתול' },
+] as const;
+
+const petGenderOptions = [
+  { value: 'male', label: 'זכר' },
+  { value: 'female', label: 'נקבה' },
+] as const;
+
+export type PetFormModalProps = {
+  opened: boolean;
+  mode: 'create' | 'edit';
+  onClose: () => void;
+  submitLoading?: boolean;
+  initialValues?: PetFormModalInitialValues | null;
+  onSubmit: (values: PetFormSubmitValues) => void | Promise<unknown>;
+};
+
+export function PetFormModal({
+  opened,
+  mode,
+  onClose,
+  submitLoading,
+  initialValues,
+  onSubmit,
+}: PetFormModalProps) {
+  const [values, setValues] = useState<PetFormValues>(initialFormValues);
+
+  useEffect(() => {
+    if (!opened) {
+      setValues(initialFormValues);
+      return;
+    }
+
+    setValues({
+      name: initialValues?.name ?? '',
+      type: initialValues?.type ?? '',
+      gender: initialValues?.gender ?? '',
+      breed: initialValues?.breed ?? '',
+    });
+  }, [opened, initialValues?.name, initialValues?.type, initialValues?.gender, initialValues?.breed]);
+
+  const submitDisabled = useMemo(() => {
+    return values.name.trim() === '' || values.type === '' || values.gender === '';
+  }, [values.gender, values.name, values.type]);
+
+  const handleSubmit = () => {
+    const trimmedName = values.name.trim();
+    const trimmedBreed = values.breed.trim();
+    if (!trimmedName || values.type === '' || values.gender === '') {
+      return;
+    }
+
+    onSubmit({
+      name: trimmedName,
+      type: values.type,
+      gender: values.gender,
+      breed: trimmedBreed === '' ? null : trimmedBreed,
+    });
+  };
+
+  return (
+    <EntityFormModal
+      opened={opened}
+      onClose={onClose}
+      title={mode === 'edit' ? 'עריכת חיית מחמד' : 'הוסף חיה חדשה'}
+      mode={mode}
+      onSubmit={handleSubmit}
+      submitDisabled={submitDisabled}
+      submitLoading={submitLoading}
+    >
+      <TextInput
+        label="שם"
+        value={values.name}
+        onChange={({ currentTarget }) => setValues((prev) => ({ ...prev, name: currentTarget.value }))}
+        required
+      />
+      <Select
+        label="סוג"
+        placeholder="בחר סוג"
+        data={petTypeOptions}
+        value={values.type}
+        onChange={(val) =>
+          setValues((prev) => ({ ...prev, type: (val as PetFormValues['type']) ?? '' }))
+        }
+        required
+      />
+      <Select
+        label="מין"
+        placeholder="בחר מין"
+        data={petGenderOptions}
+        value={values.gender}
+        onChange={(val) =>
+          setValues((prev) => ({ ...prev, gender: (val as PetFormValues['gender']) ?? '' }))
+        }
+        required
+      />
+      <TextInput
+        label="גזע"
+        value={values.breed}
+        onChange={({ currentTarget }) => setValues((prev) => ({ ...prev, breed: currentTarget.value }))}
+      />
+    </EntityFormModal>
+  );
+}

--- a/front/src/hooks/usePetUpdateMutation.ts
+++ b/front/src/hooks/usePetUpdateMutation.ts
@@ -11,7 +11,7 @@ export type UpdatePetVariables = {
 
 type UpdatePetContext = {
   previousPets: Pet[];
-  previousPetDetail?: Pet;
+  previousPetDetail: Pet | undefined;
 };
 
 type UsePetUpdateMutationParams = {
@@ -46,7 +46,7 @@ export function usePetUpdateMutation({
     errorToast: { fallbackMessage: 'עדכון חיית המחמד נכשל' },
     onMutate: async ({ petId, payload }) => {
       if (!customerId) {
-        return { previousPets: [] };
+        return { previousPets: [] as Pet[], previousPetDetail: undefined };
       }
       await queryClient.cancelQueries({ queryKey: petsQueryKey });
       if (petDetailQueryKey) {

--- a/front/src/hooks/usePetUpdateMutation.ts
+++ b/front/src/hooks/usePetUpdateMutation.ts
@@ -1,0 +1,107 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { updatePet, type Pet, type UpdatePetBody } from '../api/customers';
+import { useApiMutation } from '../lib/useApiMutation';
+import { queryKeys } from '../lib/queryKeys';
+import { applyPetUpdates } from '../utils/entityUpdates';
+
+export type UpdatePetVariables = {
+  petId: string;
+  payload: UpdatePetBody;
+};
+
+type UpdatePetContext = {
+  previousPets: Pet[];
+  previousPetDetail?: Pet;
+};
+
+type UsePetUpdateMutationParams = {
+  customerId: string | null | undefined;
+  petDetailQueryKey?: readonly unknown[];
+  onSuccess?: (
+    data: Pet | undefined,
+    variables: UpdatePetVariables,
+    context: UpdatePetContext | undefined
+  ) => void;
+};
+
+export function usePetUpdateMutation({
+  customerId,
+  petDetailQueryKey,
+  onSuccess,
+}: UsePetUpdateMutationParams) {
+  const queryClient = useQueryClient();
+  const hasCustomerId = Boolean(customerId);
+  const petsQueryKey = hasCustomerId
+    ? queryKeys.pets(customerId as string)
+    : (['pets', ''] as const);
+
+  return useApiMutation<Pet | undefined, unknown, UpdatePetVariables, UpdatePetContext>({
+    mutationFn: ({ petId, payload }) => {
+      if (!customerId) {
+        throw new Error('Missing customer id');
+      }
+      return updatePet(customerId, petId, payload);
+    },
+    successToast: { message: 'חיית המחמד עודכנה בהצלחה' },
+    errorToast: { fallbackMessage: 'עדכון חיית המחמד נכשל' },
+    onMutate: async ({ petId, payload }) => {
+      if (!customerId) {
+        return { previousPets: [] };
+      }
+      await queryClient.cancelQueries({ queryKey: petsQueryKey });
+      if (petDetailQueryKey) {
+        await queryClient.cancelQueries({ queryKey: petDetailQueryKey });
+      }
+      const previousPets = queryClient.getQueryData<Pet[]>(petsQueryKey) ?? [];
+      queryClient.setQueryData<Pet[]>(petsQueryKey, (old = []) =>
+        old.map((pet) => (pet.id === petId ? applyPetUpdates(pet, payload) : pet))
+      );
+
+      let previousPetDetail: Pet | undefined;
+      if (petDetailQueryKey) {
+        previousPetDetail = queryClient.getQueryData<Pet | undefined>(petDetailQueryKey);
+        if (previousPetDetail) {
+          queryClient.setQueryData<Pet>(
+            petDetailQueryKey,
+            applyPetUpdates(previousPetDetail, payload)
+          );
+        }
+      }
+
+      return { previousPets, previousPetDetail };
+    },
+    onError: (_error, _variables, context) => {
+      queryClient.setQueryData(petsQueryKey, context?.previousPets ?? []);
+      if (petDetailQueryKey && context?.previousPetDetail) {
+        queryClient.setQueryData(petDetailQueryKey, context.previousPetDetail);
+      }
+    },
+    onSuccess: (data, variables, context) => {
+      if (!variables) {
+        onSuccess?.(data, variables as UpdatePetVariables, context);
+        return;
+      }
+      const { petId, payload } = variables;
+      queryClient.setQueryData<Pet[]>(petsQueryKey, (old = []) =>
+        old.map((pet) =>
+          pet.id === (data?.id ?? petId) ? (data ?? applyPetUpdates(pet, payload)) : pet
+        )
+      );
+
+      if (petDetailQueryKey) {
+        queryClient.setQueryData<Pet | undefined>(
+          petDetailQueryKey,
+          (old) => data ?? (old ? applyPetUpdates(old, payload) : old)
+        );
+      }
+
+      onSuccess?.(data, variables, context);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: petsQueryKey });
+      if (petDetailQueryKey) {
+        void queryClient.invalidateQueries({ queryKey: petDetailQueryKey });
+      }
+    },
+  });
+}

--- a/front/src/pages/PetDetail.tsx
+++ b/front/src/pages/PetDetail.tsx
@@ -240,18 +240,20 @@ export function PetDetail() {
     return null;
   }
 
+  const ensuredPet = pet;
+
   function openPetEditModal() {
     setPetFormInitialValues({
-      name: pet.name,
-      type: pet.type,
-      gender: pet.gender,
-      breed: pet.breed ?? '',
+      name: ensuredPet.name,
+      type: ensuredPet.type,
+      gender: ensuredPet.gender,
+      breed: ensuredPet.breed ?? '',
     });
     setPetFormOpen(true);
   }
 
-  const typeLabel = pet.type === 'dog' ? 'כלב' : 'חתול';
-  const genderLabel = pet.gender === 'male' ? 'זכר' : 'נקבה';
+  const typeLabel = ensuredPet.type === 'dog' ? 'כלב' : 'חתול';
+  const genderLabel = ensuredPet.gender === 'male' ? 'זכר' : 'נקבה';
 
   return (
     <Container size="lg" pt={{ base: 'xl', sm: 'xl' }} pb="xl">
@@ -306,8 +308,8 @@ export function PetDetail() {
           </Menu.Dropdown>
         </Menu>
 
-        <PageTitle order={2}>{pet.name}</PageTitle>
-        <Badge variant="light" size="lg" color={pet.type === 'dog' ? 'teal' : 'grape'}>
+        <PageTitle order={2}>{ensuredPet.name}</PageTitle>
+        <Badge variant="light" size="lg" color={ensuredPet.type === 'dog' ? 'teal' : 'grape'}>
           {typeLabel}
         </Badge>
       </Group>
@@ -321,14 +323,14 @@ export function PetDetail() {
             <Badge variant="light" color="blue">
               {genderLabel}
             </Badge>
-            {pet.breed && <Badge variant="outline">{pet.breed}</Badge>}
+            {ensuredPet.breed && <Badge variant="outline">{ensuredPet.breed}</Badge>}
           </Group>
           <Stack gap="xs">
             <Text size="sm" c="dimmed">
-              מזהה חיה: {pet.id}
+              מזהה חיה: {ensuredPet.id}
             </Text>
             <Text size="sm" c="dimmed">
-              מזהה לקוח: {pet.customerId}
+              מזהה לקוח: {ensuredPet.customerId}
             </Text>
           </Stack>
         </Stack>
@@ -350,7 +352,7 @@ export function PetDetail() {
       >
         <Stack>
           <Text>
-            האם אתה בטוח שברצונך למחוק את חיית המחמד "{pet.name}"? פעולה זו אינה ניתנת לביטול.
+            האם אתה בטוח שברצונך למחוק את חיית המחמד "{ensuredPet.name}"? פעולה זו אינה ניתנת לביטול.
           </Text>
           <Group justify="right" mt="sm">
             <Button variant="default" onClick={() => setDeleteModalOpen(false)}>

--- a/front/src/pages/PetDetail.tsx
+++ b/front/src/pages/PetDetail.tsx
@@ -13,15 +13,28 @@ import {
   Stack,
   Text,
 } from '@mantine/core';
-import { IconDots, IconX } from '@tabler/icons-react';
+import { IconDots, IconPencil, IconX } from '@tabler/icons-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { getPet, deletePet, getCustomer, type Customer, type Pet } from '../api/customers';
+import {
+  getPet,
+  deletePet,
+  getCustomer,
+  type Customer,
+  type Pet,
+  type UpdatePetBody,
+} from '../api/customers';
 import { StatusCard } from '../components/StatusCard';
 import { queryKeys } from '../lib/queryKeys';
 import { extractErrorMessage } from '../lib/notifications';
 import { HttpError } from '../lib/http';
 import { useApiMutation } from '../lib/useApiMutation';
 import { PageTitle } from '../components/PageTitle';
+import {
+  PetFormModal,
+  type PetFormModalInitialValues,
+  type PetFormSubmitValues,
+} from '../components/PetFormModal';
+import { usePetUpdateMutation } from '../hooks/usePetUpdateMutation';
 
 export function PetDetail() {
   const { customerId, petId } = useParams<{ customerId: string; petId: string }>();
@@ -51,6 +64,14 @@ export function PetDetail() {
   });
 
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [petFormOpen, setPetFormOpen] = useState(false);
+  const [petFormInitialValues, setPetFormInitialValues] =
+    useState<PetFormModalInitialValues | null>(null);
+
+  function closePetForm() {
+    setPetFormOpen(false);
+    setPetFormInitialValues(null);
+  }
 
   const deletePetMutation = useApiMutation({
     mutationFn: () => deletePet(customerId!, petId!),
@@ -111,6 +132,27 @@ export function PetDetail() {
       void queryClient.invalidateQueries({ queryKey: customersListKey });
     },
   });
+
+  const updatePetMutation = usePetUpdateMutation({
+    customerId,
+    petDetailQueryKey: petQueryKey,
+    onSuccess: () => {
+      closePetForm();
+    },
+  });
+
+  const petMutationInFlight = updatePetMutation.isPending;
+
+  async function onSubmitPet(values: PetFormSubmitValues) {
+    if (!petId) return;
+    const payload: UpdatePetBody = {
+      name: values.name,
+      type: values.type,
+      gender: values.gender,
+      breed: values.breed,
+    };
+    await updatePetMutation.mutateAsync({ petId, payload });
+  }
 
   const loading = petQuery.isPending || customerQuery.isPending;
   const petError = petQuery.error;
@@ -198,6 +240,16 @@ export function PetDetail() {
     return null;
   }
 
+  function openPetEditModal() {
+    setPetFormInitialValues({
+      name: pet.name,
+      type: pet.type,
+      gender: pet.gender,
+      breed: pet.breed ?? '',
+    });
+    setPetFormOpen(true);
+  }
+
   const typeLabel = pet.type === 'dog' ? 'כלב' : 'חתול';
   const genderLabel = pet.gender === 'male' ? 'זכר' : 'נקבה';
 
@@ -232,6 +284,15 @@ export function PetDetail() {
             </Button>
           </Menu.Target>
           <Menu.Dropdown data-testid="pet-actions-dropdown">
+            <Menu.Item
+              leftSection={<IconPencil size={16} />}
+              onClick={(e) => {
+                e.stopPropagation();
+                openPetEditModal();
+              }}
+            >
+              ערוך חיית מחמד
+            </Menu.Item>
             <Menu.Item
               color="red"
               leftSection={<IconX size={16} />}
@@ -272,6 +333,15 @@ export function PetDetail() {
           </Stack>
         </Stack>
       </Card>
+
+      <PetFormModal
+        opened={petFormOpen}
+        onClose={closePetForm}
+        mode="edit"
+        submitLoading={petMutationInFlight}
+        initialValues={petFormInitialValues}
+        onSubmit={onSubmitPet}
+      />
 
       <Modal
         opened={deleteModalOpen}

--- a/front/src/pages/PetDetail.tsx
+++ b/front/src/pages/PetDetail.tsx
@@ -352,7 +352,8 @@ export function PetDetail() {
       >
         <Stack>
           <Text>
-            האם אתה בטוח שברצונך למחוק את חיית המחמד "{ensuredPet.name}"? פעולה זו אינה ניתנת לביטול.
+            האם אתה בטוח שברצונך למחוק את חיית המחמד "{ensuredPet.name}"? פעולה זו אינה ניתנת
+            לביטול.
           </Text>
           <Group justify="right" mt="sm">
             <Button variant="default" onClick={() => setDeleteModalOpen(false)}>

--- a/front/src/test/main/main.test.tsx
+++ b/front/src/test/main/main.test.tsx
@@ -49,6 +49,7 @@ describe('main.tsx entrypoint', () => {
     createRootMock.mockClear();
     renderMock.mockClear();
     document.body.innerHTML = '<div id="root"></div>';
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost');
   });
 
   afterEach(() => {

--- a/front/src/test/pages/PetDetail.mutationHandlers.test.tsx
+++ b/front/src/test/pages/PetDetail.mutationHandlers.test.tsx
@@ -53,6 +53,7 @@ vi.mock('../../api/customers', () => ({
   getPet: vi.fn(),
   deletePet: vi.fn(),
   getCustomer: vi.fn(),
+  updatePet: vi.fn(),
 }));
 
 vi.mock('@tanstack/react-query', async (importOriginal) => {

--- a/front/src/test/pages/PetDetail.test.tsx
+++ b/front/src/test/pages/PetDetail.test.tsx
@@ -147,7 +147,9 @@ describe('PetDetail page', () => {
     await waitFor(() =>
       expect(screen.queryByRole('dialog', { name: 'עריכת חיית מחמד' })).not.toBeInTheDocument()
     );
-    await waitFor(() => expect(screen.getByRole('heading', { name: 'Bolt Updated' })).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: 'Bolt Updated' })).toBeInTheDocument()
+    );
   });
 
   it('allows deleting the pet and returns to customer page', async () => {


### PR DESCRIPTION
## Summary
- add a reusable pet form modal and shared update hook to consolidate pet edit UX
- refactor the customer detail page to use the shared form logic for create and edit flows
- enable pet edits from the pet detail page and extend tests to cover the new behavior

## Testing
- npm test -- src/test/pages/PetDetail.test.tsx
- npm test -- src/test/pages/CustomerDetail.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68fcc744c2a48322894d628b6b331ce7