### PR TITLE
Morph header paw into global loading spinner

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -81,29 +81,30 @@ function ProtectedLayout() {
 export default function AppRoutes() {
   return (
     <AuthProvider>
-      <GlobalLoadingIndicator />
-      <Routes>
-        <Route element={<PlainLayout />}>
-          <Route path="/login" element={<Login />} />
-        </Route>
+      <GlobalLoadingIndicator>
+        <Routes>
+          <Route element={<PlainLayout />}>
+            <Route path="/login" element={<Login />} />
+          </Route>
 
-        <Route
-          element={
-            <ProtectedRoute>
-              <ProtectedLayout />
-            </ProtectedRoute>
-          }
-        >
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/treatments" element={<Treatments />} />
-          <Route path="/customers" element={<Customers />} />
-          <Route path="/customers/:id" element={<CustomerDetail />} />
-          <Route path="/customers/:customerId/pets/:petId" element={<PetDetail />} />
-          <Route path="/settings" element={<Settings />} />
-        </Route>
+          <Route
+            element={
+              <ProtectedRoute>
+                <ProtectedLayout />
+              </ProtectedRoute>
+            }
+          >
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/treatments" element={<Treatments />} />
+            <Route path="/customers" element={<Customers />} />
+            <Route path="/customers/:id" element={<CustomerDetail />} />
+            <Route path="/customers/:customerId/pets/:petId" element={<PetDetail />} />
+            <Route path="/settings" element={<Settings />} />
+          </Route>
 
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </GlobalLoadingIndicator>
     </AuthProvider>
   );
 }

--- a/front/src/Header.module.css
+++ b/front/src/Header.module.css
@@ -15,25 +15,28 @@
 }
 
 .brandPawIcon[data-loading='true'] {
-  animation: paw-spin 1.1s ease-in-out infinite;
-  filter: drop-shadow(0 0 0.6rem currentColor);
-  color: var(--mantine-color-orange-6);
+  animation: paw-pulse 1.4s ease-in-out infinite;
+  filter: drop-shadow(0 0 0.75rem currentColor);
+  color: var(--mantine-color-blue-4);
 }
 
 [data-mantine-color-scheme='dark'] .brandPawIcon[data-loading='true'] {
-  color: var(--mantine-color-orange-4);
+  color: var(--mantine-color-blue-2);
 }
 
-@keyframes paw-spin {
+@keyframes paw-pulse {
   0% {
-    transform: rotate(0deg) scale(1);
+    transform: scale(1);
+    opacity: 0.85;
   }
 
   50% {
-    transform: rotate(180deg) scale(0.92);
+    transform: scale(1.12);
+    opacity: 1;
   }
 
   100% {
-    transform: rotate(360deg) scale(1);
+    transform: scale(1);
+    opacity: 0.85;
   }
 }

--- a/front/src/Header.module.css
+++ b/front/src/Header.module.css
@@ -11,7 +11,9 @@
 }
 
 .brandPawIcon {
-  transition: color 150ms ease, filter 150ms ease;
+  transition:
+    color 150ms ease,
+    filter 150ms ease;
 }
 
 .brandPawIcon[data-loading='true'] {

--- a/front/src/Header.module.css
+++ b/front/src/Header.module.css
@@ -17,6 +17,11 @@
 .brandPawIcon[data-loading='true'] {
   animation: paw-spin 1.1s ease-in-out infinite;
   filter: drop-shadow(0 0 0.6rem currentColor);
+  color: var(--mantine-color-orange-6);
+}
+
+[data-mantine-color-scheme='dark'] .brandPawIcon[data-loading='true'] {
+  color: var(--mantine-color-orange-4);
 }
 
 @keyframes paw-spin {

--- a/front/src/Header.module.css
+++ b/front/src/Header.module.css
@@ -1,0 +1,34 @@
+.branding {
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-xs);
+}
+
+.brandPaw {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.brandPawIcon {
+  transition: color 150ms ease, filter 150ms ease;
+}
+
+.brandPawIcon[data-loading='true'] {
+  animation: paw-spin 1.1s ease-in-out infinite;
+  filter: drop-shadow(0 0 0.6rem currentColor);
+}
+
+@keyframes paw-spin {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+
+  50% {
+    transform: rotate(180deg) scale(0.92);
+  }
+
+  100% {
+    transform: rotate(360deg) scale(1);
+  }
+}

--- a/front/src/Header.tsx
+++ b/front/src/Header.tsx
@@ -1,7 +1,9 @@
-import { AppShell, Avatar, Burger, Button, Divider, Group, Menu, Title } from '@mantine/core';
+import { AppShell, Avatar, Burger, Button, Divider, Group, Menu, Title, useMantineTheme } from '@mantine/core';
 import { IconChevronDown, IconLogout, IconPawFilled, IconSettings } from '@tabler/icons-react';
 import { useAuth } from './auth/AuthContext';
 import { Link } from 'react-router-dom';
+import { useGlobalLoading } from './components/GlobalLoadingIndicator';
+import classes from './Header.module.css';
 
 export default function Header({
   opened,
@@ -11,6 +13,9 @@ export default function Header({
   setOpened: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const { logout, user } = useAuth();
+  const theme = useMantineTheme();
+  const isLoading = useGlobalLoading();
+  const accentColor = theme.colors.orange[theme.colorScheme === 'dark' ? 4 : 6];
 
   return (
     <AppShell.Header>
@@ -23,8 +28,22 @@ export default function Header({
             size="sm"
           />
 
-          <Title order={6}>
-            <IconPawFilled /> kalimere::vet
+          <Title order={6} className={classes.branding}>
+            <span
+              role="status"
+              aria-live="polite"
+              aria-label={isLoading ? 'Loading data' : 'Ready'}
+              className={classes.brandPaw}
+            >
+              <IconPawFilled
+                aria-hidden
+                size={22}
+                className={classes.brandPawIcon}
+                data-loading={isLoading ? 'true' : undefined}
+                style={{ color: isLoading ? accentColor : undefined }}
+              />
+            </span>
+            kalimere::vet
           </Title>
         </Group>
 

--- a/front/src/Header.tsx
+++ b/front/src/Header.tsx
@@ -1,4 +1,4 @@
-import { AppShell, Avatar, Burger, Button, Divider, Group, Menu, Title, useMantineTheme } from '@mantine/core';
+import { AppShell, Avatar, Burger, Button, Divider, Group, Menu, Title } from '@mantine/core';
 import { IconChevronDown, IconLogout, IconPawFilled, IconSettings } from '@tabler/icons-react';
 import { useAuth } from './auth/AuthContext';
 import { Link } from 'react-router-dom';
@@ -13,9 +13,7 @@ export default function Header({
   setOpened: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const { logout, user } = useAuth();
-  const theme = useMantineTheme();
   const isLoading = useGlobalLoading();
-  const accentColor = theme.colors.orange[theme.colorScheme === 'dark' ? 4 : 6];
 
   return (
     <AppShell.Header>
@@ -28,19 +26,18 @@ export default function Header({
             size="sm"
           />
 
-          <Title order={6} className={classes.branding}>
+          <Title order={6} className={classes['branding'] ?? ''}>
             <span
               role="status"
               aria-live="polite"
               aria-label={isLoading ? 'Loading data' : 'Ready'}
-              className={classes.brandPaw}
+              className={classes['brandPaw'] ?? ''}
             >
               <IconPawFilled
                 aria-hidden
                 size={22}
-                className={classes.brandPawIcon}
+                className={classes['brandPawIcon'] ?? ''}
                 data-loading={isLoading ? 'true' : undefined}
-                style={{ color: isLoading ? accentColor : undefined }}
               />
             </span>
             kalimere::vet

--- a/front/src/components/GlobalLoadingIndicator.tsx
+++ b/front/src/components/GlobalLoadingIndicator.tsx
@@ -1,10 +1,15 @@
-import { useEffect, useState } from 'react';
-import { Group, Loader, Paper, Portal, Text, Transition } from '@mantine/core';
+import { createContext, type ReactNode, useContext, useEffect, useState } from 'react';
 import { useIsFetching, useIsMutating } from '@tanstack/react-query';
 
 const HIDE_DELAY_MS = 300;
 
-export function GlobalLoadingIndicator() {
+const GlobalLoadingContext = createContext(false);
+
+export function useGlobalLoading() {
+  return useContext(GlobalLoadingContext);
+}
+
+export function GlobalLoadingIndicator({ children }: { children?: ReactNode }) {
   const isFetching = useIsFetching();
   const isMutating = useIsMutating();
   const busy = isFetching + isMutating > 0;
@@ -17,36 +22,13 @@ export function GlobalLoadingIndicator() {
     } else {
       timeout = setTimeout(() => setVisible(false), HIDE_DELAY_MS);
     }
+
     return () => {
-      if (timeout) clearTimeout(timeout);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
     };
   }, [busy]);
 
-  return (
-    <Portal>
-      <Transition mounted={visible} transition="slide-down" duration={150} timingFunction="ease">
-        {(styles) => (
-          <Paper
-            shadow="lg"
-            radius="xl"
-            withBorder
-            style={{
-              position: 'fixed',
-              top: 16,
-              right: 16,
-              zIndex: 2000,
-              ...styles,
-            }}
-          >
-            <Group gap="xs" p="sm">
-              <Loader size="xs" />
-              <Text size="sm" c="dimmed">
-                טוען נתונים...
-              </Text>
-            </Group>
-          </Paper>
-        )}
-      </Transition>
-    </Portal>
-  );
+  return <GlobalLoadingContext.Provider value={visible}>{children}</GlobalLoadingContext.Provider>;
 }

--- a/front/src/global.d.ts
+++ b/front/src/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}

--- a/front/src/test/components/GlobalLoadingIndicator.test.tsx
+++ b/front/src/test/components/GlobalLoadingIndicator.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { act, screen } from '@testing-library/react';
-import { GlobalLoadingIndicator } from '../../components/GlobalLoadingIndicator';
+import { GlobalLoadingIndicator, useGlobalLoading } from '../../components/GlobalLoadingIndicator';
 import { renderWithProviders } from '../utils/renderWithProviders';
 import { useIsFetching, useIsMutating } from '@tanstack/react-query';
 
@@ -15,6 +15,11 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
 
 const useIsFetchingMock = vi.mocked(useIsFetching);
 const useIsMutatingMock = vi.mocked(useIsMutating);
+
+function LoadingConsumer() {
+  const busy = useGlobalLoading();
+  return <span>{busy ? 'busy' : 'idle'}</span>;
+}
 
 describe('GlobalLoadingIndicator', () => {
   let timeoutSpy: MockInstance<typeof global.setTimeout>;
@@ -31,26 +36,44 @@ describe('GlobalLoadingIndicator', () => {
     vi.useRealTimers();
   });
 
-  it('shows loader while there are active queries or mutations', () => {
+  it('reports loading state while there are active queries or mutations', () => {
     useIsFetchingMock.mockReturnValue(1);
     useIsMutatingMock.mockReturnValue(0);
 
-    renderWithProviders(<GlobalLoadingIndicator />);
+    renderWithProviders(
+      <GlobalLoadingIndicator>
+        <LoadingConsumer />
+      </GlobalLoadingIndicator>,
+    );
 
-    expect(screen.getByText('טוען נתונים...')).toBeInTheDocument();
+    expect(screen.getByText('busy')).toBeInTheDocument();
   });
 
-  it('schedules hide timeout when activity stops', () => {
+  it('delays clearing the loading state after activity stops', () => {
     useIsFetchingMock.mockReturnValueOnce(1).mockReturnValue(0);
     useIsMutatingMock.mockReturnValue(0);
 
-    const { rerender } = renderWithProviders(<GlobalLoadingIndicator />);
-    expect(screen.getByText('טוען נתונים...')).toBeInTheDocument();
+    const { rerender } = renderWithProviders(
+      <GlobalLoadingIndicator>
+        <LoadingConsumer />
+      </GlobalLoadingIndicator>,
+    );
+    expect(screen.getByText('busy')).toBeInTheDocument();
 
     act(() => {
-      rerender(<GlobalLoadingIndicator />);
+      rerender(
+        <GlobalLoadingIndicator>
+          <LoadingConsumer />
+        </GlobalLoadingIndicator>,
+      );
     });
 
     expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 300);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(screen.getByText('idle')).toBeInTheDocument();
   });
 });

--- a/front/src/test/components/GlobalLoadingIndicator.test.tsx
+++ b/front/src/test/components/GlobalLoadingIndicator.test.tsx
@@ -43,7 +43,7 @@ describe('GlobalLoadingIndicator', () => {
     renderWithProviders(
       <GlobalLoadingIndicator>
         <LoadingConsumer />
-      </GlobalLoadingIndicator>,
+      </GlobalLoadingIndicator>
     );
 
     expect(screen.getByText('busy')).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe('GlobalLoadingIndicator', () => {
     const { rerender } = renderWithProviders(
       <GlobalLoadingIndicator>
         <LoadingConsumer />
-      </GlobalLoadingIndicator>,
+      </GlobalLoadingIndicator>
     );
     expect(screen.getByText('busy')).toBeInTheDocument();
 
@@ -64,7 +64,7 @@ describe('GlobalLoadingIndicator', () => {
       rerender(
         <GlobalLoadingIndicator>
           <LoadingConsumer />
-        </GlobalLoadingIndicator>,
+        </GlobalLoadingIndicator>
       );
     });
 

--- a/front/src/test/main/main.test.tsx
+++ b/front/src/test/main/main.test.tsx
@@ -49,6 +49,7 @@ describe('main.tsx entrypoint', () => {
     createRootMock.mockClear();
     renderMock.mockClear();
     document.body.innerHTML = '<div id="root"></div>';
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost');
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- replace the global loading portal with a context provider so the header paw reflects background activity
- animate the header paw icon into a spinner using a dedicated CSS module and shared indicator hook
- add CSS module type declarations and refresh unit tests for the new loading indicator behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fcd4d718388322a2b16ef8af29be16