### PR TITLE
feat: expand visit data model

### DIFF
--- a/api/drizzle/0000_purple_scourge.sql
+++ b/api/drizzle/0000_purple_scourge.sql
@@ -1,5 +1,6 @@
 CREATE TYPE "public"."pet_gender" AS ENUM('male', 'female');--> statement-breakpoint
 CREATE TYPE "public"."pet_type" AS ENUM('dog', 'cat');--> statement-breakpoint
+CREATE TYPE "public"."visit_status" AS ENUM('scheduled', 'completed', 'cancelled');--> statement-breakpoint
 CREATE TABLE "appointments" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"pet_id" uuid NOT NULL,
@@ -75,23 +76,37 @@ CREATE TABLE "users" (
 );
 --> statement-breakpoint
 CREATE TABLE "visit_treatments" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-	"visit_id" uuid NOT NULL,
-	"treatment_id" uuid NOT NULL,
-	"next_due_date" date,
-	"is_deleted" boolean DEFAULT false NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+        "visit_id" uuid NOT NULL,
+        "treatment_id" uuid NOT NULL,
+        "price_cents" integer,
+        "next_due_date" date,
+        "is_deleted" boolean DEFAULT false NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "visits" (
-	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
-	"pet_id" uuid NOT NULL,
-	"visit_date" date NOT NULL,
-	"summary" text NOT NULL,
-	"is_deleted" boolean DEFAULT false NOT NULL,
-	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
-	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+        "pet_id" uuid NOT NULL,
+        "customer_id" uuid NOT NULL,
+        "status" "visit_status" DEFAULT 'scheduled' NOT NULL,
+        "scheduled_start_at" timestamp with time zone NOT NULL,
+        "scheduled_end_at" timestamp with time zone,
+        "completed_at" timestamp with time zone,
+        "title" text,
+        "description" text,
+        "is_deleted" boolean DEFAULT false NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "visit_notes" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+        "visit_id" uuid NOT NULL,
+        "note" text NOT NULL,
+        "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+        "updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 ALTER TABLE "appointments" ADD CONSTRAINT "appointments_pet_id_pets_id_fk" FOREIGN KEY ("pet_id") REFERENCES "public"."pets"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
@@ -103,6 +118,8 @@ ALTER TABLE "treatments" ADD CONSTRAINT "treatments_user_id_users_id_fk" FOREIGN
 ALTER TABLE "visit_treatments" ADD CONSTRAINT "visit_treatments_visit_id_visits_id_fk" FOREIGN KEY ("visit_id") REFERENCES "public"."visits"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "visit_treatments" ADD CONSTRAINT "visit_treatments_treatment_id_treatments_id_fk" FOREIGN KEY ("treatment_id") REFERENCES "public"."treatments"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "visits" ADD CONSTRAINT "visits_pet_id_pets_id_fk" FOREIGN KEY ("pet_id") REFERENCES "public"."pets"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visits" ADD CONSTRAINT "visits_customer_id_customers_id_fk" FOREIGN KEY ("customer_id") REFERENCES "public"."customers"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "visit_notes" ADD CONSTRAINT "visit_notes_visit_id_visits_id_fk" FOREIGN KEY ("visit_id") REFERENCES "public"."visits"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "appointment_pet_idx" ON "appointments" USING btree ("pet_id");--> statement-breakpoint
 CREATE INDEX "appointment_customer_idx" ON "appointments" USING btree ("customer_id");--> statement-breakpoint
 CREATE INDEX "customer_user_idx" ON "customers" USING btree ("user_id");--> statement-breakpoint
@@ -112,4 +129,7 @@ CREATE INDEX "session_user_idx" ON "sessions" USING btree ("user_id");--> statem
 CREATE INDEX "treatment_user_idx" ON "treatments" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX "visit_treatment_visit_idx" ON "visit_treatments" USING btree ("visit_id");--> statement-breakpoint
 CREATE INDEX "visit_treatment_treatment_idx" ON "visit_treatments" USING btree ("treatment_id");--> statement-breakpoint
-CREATE INDEX "visit_pet_idx" ON "visits" USING btree ("pet_id");
+CREATE INDEX "visit_note_visit_idx" ON "visit_notes" USING btree ("visit_id");--> statement-breakpoint
+CREATE INDEX "visit_pet_idx" ON "visits" USING btree ("pet_id");--> statement-breakpoint
+CREATE INDEX "visit_customer_idx" ON "visits" USING btree ("customer_id");--> statement-breakpoint
+CREATE INDEX "visit_status_idx" ON "visits" USING btree ("status");

--- a/api/drizzle/meta/0000_snapshot.json
+++ b/api/drizzle/meta/0000_snapshot.json
@@ -636,6 +636,12 @@
           "primaryKey": false,
           "notNull": true
         },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
         "next_due_date": {
           "name": "next_due_date",
           "type": "date",
@@ -722,6 +728,78 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
+    "public.visit_notes": {
+      "name": "visit_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "visit_id": {
+          "name": "visit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "visit_note_visit_idx": {
+          "name": "visit_note_visit_idx",
+          "columns": [
+            {
+              "expression": "visit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "visit_notes_visit_id_visits_id_fk": {
+          "name": "visit_notes_visit_id_visits_id_fk",
+          "tableFrom": "visit_notes",
+          "tableTo": "visits",
+          "columnsFrom": ["visit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
     "public.visits": {
       "name": "visits",
       "schema": "",
@@ -739,17 +817,48 @@
           "primaryKey": false,
           "notNull": true
         },
-        "visit_date": {
-          "name": "visit_date",
-          "type": "date",
+        "customer_id": {
+          "name": "customer_id",
+          "type": "uuid",
           "primaryKey": false,
           "notNull": true
         },
-        "summary": {
-          "name": "summary",
-          "type": "text",
+        "status": {
+          "name": "status",
+          "type": "visit_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "scheduled"
+        },
+        "scheduled_start_at": {
+          "name": "scheduled_start_at",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
+        },
+        "scheduled_end_at": {
+          "name": "scheduled_end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
         },
         "is_deleted": {
           "name": "is_deleted",
@@ -788,6 +897,36 @@
           "concurrently": false,
           "method": "btree",
           "with": {}
+        },
+        "visit_customer_idx": {
+          "name": "visit_customer_idx",
+          "columns": [
+            {
+              "expression": "customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "visit_status_idx": {
+          "name": "visit_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
         }
       },
       "foreignKeys": {
@@ -796,6 +935,15 @@
           "tableFrom": "visits",
           "tableTo": "pets",
           "columnsFrom": ["pet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "visits_customer_id_customers_id_fk": {
+          "name": "visits_customer_id_customers_id_fk",
+          "tableFrom": "visits",
+          "tableTo": "customers",
+          "columnsFrom": ["customer_id"],
           "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
@@ -818,6 +966,11 @@
       "name": "pet_type",
       "schema": "public",
       "values": ["dog", "cat"]
+    },
+    "public.visit_status": {
+      "name": "visit_status",
+      "schema": "public",
+      "values": ["scheduled", "completed", "cancelled"]
     }
   },
   "schemas": {},

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,8 @@
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit push --force"
+    "db:migrate": "drizzle-kit push",
+    "db:migrate:force": "drizzle-kit push --force"
   },
   "engines": {
     "node": ">=20"

--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit push"
+    "db:migrate": "drizzle-kit push --force"
   },
   "engines": {
     "node": ">=20"

--- a/api/tests/setup.ts
+++ b/api/tests/setup.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { afterAll } from 'vitest';
+import { afterAll, vi } from 'vitest';
 
 // Set consistent defaults for test env. Individual tests can override via module mocks when needed.
 process.env.NODE_ENV = 'test';
@@ -14,6 +14,44 @@ process.env.TWILIO_WHATSAPP_FROM = 'whatsapp:+19000000000';
 process.env.URL = 'http://localhost:3000';
 process.env.RATE_LIMIT_MAX = '100';
 process.env.RATE_LIMIT_TIME_WINDOW = '1000';
+
+// Avoid hitting the real Google OIDC discovery endpoint during tests.
+vi.mock('openid-client', () => {
+  const discovery = vi.fn(async (_issuer: URL, clientId: string) => ({
+    authorization_endpoint: 'https://example.com/oauth2/v2/auth',
+    token_endpoint: 'https://example.com/oauth2/v2/token',
+    issuer: 'https://example.com',
+    jwks_uri: 'https://example.com/.well-known/jwks.json',
+    response_types_supported: ['code'],
+    id_token_signing_alg_values_supported: ['RS256'],
+    code_challenge_methods_supported: ['S256'],
+    client_id: clientId,
+  }));
+
+  const buildAuthorizationUrl = vi.fn(
+    () => new URL('https://example.com/oauth2/v2/auth?state=state&nonce=nonce')
+  );
+
+  const authorizationCodeGrant = vi.fn(async () => ({
+    claims: () => ({
+      sub: 'google-user',
+      email: 'tester@example.com',
+      email_verified: true,
+      name: 'Test User',
+      picture: 'https://example.com/avatar.png',
+    }),
+  }));
+
+  return {
+    __esModule: true,
+    discovery,
+    buildAuthorizationUrl,
+    authorizationCodeGrant,
+    randomState: vi.fn(() => 'state'),
+    randomNonce: vi.fn(() => 'nonce'),
+    ClientSecretPost: vi.fn(() => ({ type: 'client_secret_post' })),
+  };
+});
 
 afterAll(async () => {
   const tasks: Array<Promise<unknown>> = [];

--- a/api/tests/utils/db.ts
+++ b/api/tests/utils/db.ts
@@ -6,6 +6,7 @@ import {
   pets,
   sessions,
   users,
+  visitNotes,
   visitTreatments,
   visits,
   treatments,
@@ -13,6 +14,7 @@ import {
 
 export async function resetDb() {
   await db.delete(visitTreatments);
+  await db.delete(visitNotes);
   await db.delete(appointments);
   await db.delete(visits);
   await db.delete(pets);

--- a/front/src/test/main/main.test.tsx
+++ b/front/src/test/main/main.test.tsx
@@ -46,6 +46,7 @@ describe('main.tsx entrypoint', () => {
   };
 
   beforeEach(() => {
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost');
     createRootMock.mockClear();
     renderMock.mockClear();
     document.body.innerHTML = '<div id="root"></div>';
@@ -58,6 +59,7 @@ describe('main.tsx entrypoint', () => {
 
   it('creates the root element and renders the app tree', async () => {
     vi.resetModules();
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost');
     await import('../../main');
 
     const rootElement = document.getElementById('root');
@@ -71,6 +73,7 @@ describe('main.tsx entrypoint', () => {
 
   it('includes ReactQueryDevtools when running in development', async () => {
     vi.stubEnv('DEV', true);
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost');
     vi.resetModules();
     await import('../../main');
 
@@ -80,6 +83,7 @@ describe('main.tsx entrypoint', () => {
 
   it('omits ReactQueryDevtools outside of development', async () => {
     vi.stubEnv('DEV', false);
+    vi.stubEnv('VITE_API_BASE_URL', 'http://localhost');
     vi.resetModules();
     await import('../../main');
 

--- a/types/src/common.ts
+++ b/types/src/common.ts
@@ -29,3 +29,12 @@ export const okResponseSchema = z.object({ ok: z.literal(true) });
 export const nullableNumber = z.union([z.number().finite(), z.literal(null)]);
 
 export const optionalNullableNumber = nullableNumber.optional();
+
+export const isoDateTime = z
+  .string()
+  .trim()
+  .datetime({ offset: true });
+
+export const nullableIsoDateTime = z.union([isoDateTime, z.literal(null)]);
+
+export const optionalNullableIsoDateTime = nullableIsoDateTime.optional();

--- a/types/src/visits.ts
+++ b/types/src/visits.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+import {
+  isoDateTime,
+  nullableIsoDateTime,
+  nullableNumber,
+  nullableString,
+  nonEmptyString,
+  optionalNullableIsoDateTime,
+  optionalNullableDateInput,
+  optionalNullableNumber,
+  optionalNullableString,
+  uuidSchema,
+} from './common.js';
+
+export const visitStatusSchema = z.enum(['scheduled', 'completed', 'cancelled']);
+
+export const visitTreatmentSchema = z.object({
+  id: uuidSchema,
+  visitId: uuidSchema,
+  treatmentId: uuidSchema,
+  priceCents: nullableNumber,
+  nextDueDate: z.union([z.string(), z.null()]),
+  createdAt: isoDateTime,
+  updatedAt: isoDateTime,
+});
+
+export const visitNoteSchema = z.object({
+  id: uuidSchema,
+  visitId: uuidSchema,
+  note: nonEmptyString,
+  createdAt: isoDateTime,
+  updatedAt: isoDateTime,
+});
+
+export const visitSchema = z.object({
+  id: uuidSchema,
+  petId: uuidSchema,
+  customerId: uuidSchema,
+  status: visitStatusSchema,
+  scheduledStartAt: isoDateTime,
+  scheduledEndAt: nullableIsoDateTime,
+  completedAt: nullableIsoDateTime,
+  title: nullableString,
+  description: nullableString,
+  createdAt: isoDateTime,
+  updatedAt: isoDateTime,
+});
+
+export const visitWithDetailsSchema = visitSchema.extend({
+  treatments: z.array(visitTreatmentSchema),
+  notes: z.array(visitNoteSchema),
+});
+
+const visitTreatmentInputSchema = z
+  .object({
+    treatmentId: uuidSchema,
+    priceCents: optionalNullableNumber,
+    nextDueDate: optionalNullableDateInput,
+  })
+  .strict();
+
+const visitNoteInputSchema = z
+  .object({
+    note: nonEmptyString,
+  })
+  .strict();
+
+export const createVisitBodySchema = z
+  .object({
+    petId: uuidSchema,
+    customerId: uuidSchema,
+    scheduledStartAt: isoDateTime,
+    scheduledEndAt: optionalNullableIsoDateTime,
+    status: visitStatusSchema.optional(),
+    completedAt: optionalNullableIsoDateTime,
+    title: optionalNullableString,
+    description: optionalNullableString,
+    treatments: z.array(visitTreatmentInputSchema).optional(),
+    notes: z.array(visitNoteInputSchema).optional(),
+  })
+  .strict();
+
+export const updateVisitParamsSchema = z.object({
+  id: uuidSchema,
+});
+
+export const updateVisitBodySchema = z
+  .object({
+    status: visitStatusSchema.optional(),
+    scheduledStartAt: isoDateTime.optional(),
+    scheduledEndAt: optionalNullableIsoDateTime,
+    completedAt: optionalNullableIsoDateTime,
+    title: optionalNullableString,
+    description: optionalNullableString,
+    treatments: z.array(visitTreatmentInputSchema).optional(),
+    notes: z.array(visitNoteInputSchema).optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    if (!Object.values(data).some((value) => value !== undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'At least one field must be provided',
+        path: [],
+      });
+    }
+  });
+
+export const visitParamsSchema = z.object({
+  id: uuidSchema,
+});
+
+export type VisitStatus = z.infer<typeof visitStatusSchema>;
+export type VisitTreatment = z.infer<typeof visitTreatmentSchema>;
+export type VisitNote = z.infer<typeof visitNoteSchema>;
+export type Visit = z.infer<typeof visitSchema>;
+export type VisitWithDetails = z.infer<typeof visitWithDetailsSchema>;
+export type CreateVisitBody = z.infer<typeof createVisitBodySchema>;
+export type UpdateVisitParams = z.infer<typeof updateVisitParamsSchema>;
+export type UpdateVisitBody = z.infer<typeof updateVisitBodySchema>;
+export type VisitParams = z.infer<typeof visitParamsSchema>;


### PR DESCRIPTION
## Summary
- extend the visits table with scheduling metadata, status tracking, and a direct customer relationship
- allow visit-specific treatment overrides and capture free-form visit notes in a dedicated table
- add shared Zod schemas for visit payloads and update common helpers for ISO timestamps

## Testing
- npm run build (types)


------
https://chatgpt.com/codex/tasks/task_e_68fcd46621688322bdc7a25e3c93be8b