### PR TITLE
Add visit customer migration and test coverage

### DIFF
--- a/api/drizzle/0001_add_customer_id_to_visits.sql
+++ b/api/drizzle/0001_add_customer_id_to_visits.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "visits" ADD COLUMN IF NOT EXISTS "customer_id" uuid;--> statement-breakpoint
+UPDATE "visits"
+SET "customer_id" = p."customer_id"
+FROM "pets" AS p
+WHERE "visits"."pet_id" = p."id" AND "visits"."customer_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "visits"
+  ALTER COLUMN "customer_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "visits"
+  DROP CONSTRAINT IF EXISTS "visits_customer_id_customers_id_fk";--> statement-breakpoint
+ALTER TABLE "visits"
+  ADD CONSTRAINT "visits_customer_id_customers_id_fk"
+    FOREIGN KEY ("customer_id") REFERENCES "customers"("id")
+    ON DELETE NO ACTION ON UPDATE NO ACTION;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "visit_customer_idx" ON "visits" USING btree ("customer_id");

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1760085803200,
       "tag": "0000_purple_scourge",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1760086803200,
+      "tag": "0001_add_customer_id_to_visits",
+      "breakpoints": false
     }
   ]
 }

--- a/api/tests/routes/visits.test.ts
+++ b/api/tests/routes/visits.test.ts
@@ -87,6 +87,10 @@ describe('routes/visits', () => {
     const listResult = getJson<VisitsListResponse>(listResponse);
     expect(listResult.statusCode).toBe(200);
     expect(listResult.body.visits).toHaveLength(1);
+    expect(listResult.body.visits[0]).toMatchObject({
+      customerId: customer.id,
+      petId: pet.id,
+    });
 
     const visitId = createResult.body.visit.id;
 

--- a/api/tests/services/visit-service.test.ts
+++ b/api/tests/services/visit-service.test.ts
@@ -116,6 +116,7 @@ describe('visit-service', () => {
     expect(visits[0]).toMatchObject({
       title: 'Later visit',
       scheduledEndAt: null,
+      customerId: customer.id,
     });
   });
 


### PR DESCRIPTION
## Summary
- add a forward-compatible migration to backfill `visits.customer_id`, enforce the foreign key, and create the supporting index
- record the migration in the Drizzle journal
- extend visit service and route tests to assert the customer relationship is always returned

## Testing
- npm run test --prefix api -- tests/services/visit-service.test.ts tests/routes/visits.test.ts *(fails: Fastify test harness hits `isFluentSchema` undefined before exercising routes)*
- npm run lint --prefix api
- npm run type-check --prefix api *(fails: existing missing exports from `@kalimere/types/visits`)*

------
https://chatgpt.com/codex/tasks/task_e_6905ff89ad708322be8b3cc913d9a7f0